### PR TITLE
Session and storage bugfix

### DIFF
--- a/src/main/java/hirelah/logic/commands/StartInterviewCommand.java
+++ b/src/main/java/hirelah/logic/commands/StartInterviewCommand.java
@@ -1,5 +1,6 @@
 package hirelah.logic.commands;
 
+import static hirelah.logic.util.CommandUtil.saveInterviewees;
 import static hirelah.logic.util.CommandUtil.saveTranscript;
 
 import hirelah.commons.util.ModelUtil;
@@ -30,6 +31,7 @@ public class StartInterviewCommand extends Command {
             Interviewee interviewee = model.getIntervieweeList().getInterviewee(identifier);
             model.startInterview(interviewee);
             saveTranscript(model, storage);
+            saveInterviewees(model, storage);
             return new ToggleCommandResult(String.format(MESSAGE_SUCCESS, interviewee), ToggleView.TRANSCRIPT);
         } catch (IllegalActionException e) {
             throw new CommandException(e.getMessage());

--- a/src/main/java/hirelah/logic/commands/StartInterviewCommand.java
+++ b/src/main/java/hirelah/logic/commands/StartInterviewCommand.java
@@ -1,5 +1,7 @@
 package hirelah.logic.commands;
 
+import static hirelah.logic.util.CommandUtil.saveTranscript;
+
 import hirelah.commons.util.ModelUtil;
 import hirelah.logic.commands.exceptions.CommandException;
 import hirelah.model.Model;
@@ -27,6 +29,7 @@ public class StartInterviewCommand extends Command {
         try {
             Interviewee interviewee = model.getIntervieweeList().getInterviewee(identifier);
             model.startInterview(interviewee);
+            saveTranscript(model, storage);
             return new ToggleCommandResult(String.format(MESSAGE_SUCCESS, interviewee), ToggleView.TRANSCRIPT);
         } catch (IllegalActionException e) {
             throw new CommandException(e.getMessage());

--- a/src/main/java/hirelah/logic/commands/UploadResumeCommand.java
+++ b/src/main/java/hirelah/logic/commands/UploadResumeCommand.java
@@ -1,9 +1,10 @@
 package hirelah.logic.commands;
 
+import static hirelah.logic.util.CommandUtil.saveInterviewees;
+
 import java.io.File;
 
 import hirelah.logic.commands.exceptions.CommandException;
-import hirelah.logic.util.CommandUtil;
 import hirelah.model.Model;
 import hirelah.model.hirelah.Interviewee;
 import hirelah.model.hirelah.exceptions.IllegalActionException;
@@ -54,7 +55,7 @@ public class UploadResumeCommand extends Command {
             throw new CommandException(MESSAGE_FILE_NOT_FOUND);
         }
         interviewee.setResume(resume);
-        CommandUtil.saveInterviewees(model, storage);
+        saveInterviewees(model, storage);
         return new ToggleCommandResult(MESSAGE_SUCCESS, ToggleView.INTERVIEWEE);
     }
 

--- a/src/main/java/hirelah/logic/commands/interview/EndCommand.java
+++ b/src/main/java/hirelah/logic/commands/interview/EndCommand.java
@@ -1,6 +1,6 @@
 package hirelah.logic.commands.interview;
 
-import java.io.IOException;
+import static hirelah.logic.util.CommandUtil.saveTranscript;
 
 import hirelah.logic.commands.Command;
 import hirelah.logic.commands.CommandResult;
@@ -33,11 +33,7 @@ public class EndCommand extends Command {
         CommandResult result = new ToggleCommandResult(
                 String.format(MESSAGE_SUCCESS, model.getCurrentInterviewee()),
                 ToggleView.INTERVIEWEE);
-        try {
-            storage.saveTranscript(model.getCurrentInterviewee());
-        } catch (IOException e) {
-            throw new CommandException("Error occurred while saving data!");
-        }
+        saveTranscript(model, storage);
         model.endInterview();
         return result;
     }

--- a/src/main/java/hirelah/logic/commands/interview/RemarkCommand.java
+++ b/src/main/java/hirelah/logic/commands/interview/RemarkCommand.java
@@ -1,6 +1,6 @@
 package hirelah.logic.commands.interview;
 
-import java.io.IOException;
+import static hirelah.logic.util.CommandUtil.saveTranscript;
 
 import hirelah.logic.commands.Command;
 import hirelah.logic.commands.CommandResult;
@@ -27,11 +27,7 @@ public class RemarkCommand extends Command {
             throw new CommandException("Remark can not be blank.");
         }
         model.getCurrentTranscript().addRemark(this.remark);
-        try {
-            storage.saveTranscript(model.getCurrentInterviewee());
-        } catch (IOException e) {
-            throw new CommandException("Error occurred while saving data!");
-        }
+        saveTranscript(model, storage);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/hirelah/logic/commands/interview/ScoreCommand.java
+++ b/src/main/java/hirelah/logic/commands/interview/ScoreCommand.java
@@ -1,6 +1,6 @@
 package hirelah.logic.commands.interview;
 
-import java.io.IOException;
+import static hirelah.logic.util.CommandUtil.saveTranscript;
 
 import hirelah.commons.exceptions.IllegalValueException;
 import hirelah.logic.commands.Command;
@@ -40,11 +40,7 @@ public class ScoreCommand extends Command {
             throw new CommandException(e.getMessage());
         }
         model.getCurrentTranscript().setAttributeScore(attribute, this.score);
-        try {
-            storage.saveTranscript(model.getCurrentInterviewee());
-        } catch (IOException e) {
-            throw new CommandException("Error occurred while saving data!");
-        }
+        saveTranscript(model, storage);
         return new CommandResult(String.format(MESSAGE_SUCCESS, this.score, attribute));
     }
 

--- a/src/main/java/hirelah/logic/commands/interview/StartQuestionCommand.java
+++ b/src/main/java/hirelah/logic/commands/interview/StartQuestionCommand.java
@@ -1,6 +1,6 @@
 package hirelah.logic.commands.interview;
 
-import java.io.IOException;
+import static hirelah.logic.util.CommandUtil.saveTranscript;
 
 import hirelah.commons.exceptions.IllegalValueException;
 import hirelah.logic.commands.Command;
@@ -33,11 +33,7 @@ public class StartQuestionCommand extends Command {
         } catch (IllegalValueException | IllegalActionException e) {
             throw new CommandException(e.getMessage());
         }
-        try {
-            storage.saveTranscript(model.getCurrentInterviewee());
-        } catch (IOException e) {
-            throw new CommandException("Error while saving data!");
-        }
+        saveTranscript(model, storage);
         return new CommandResult(String.format(MESSAGE_SUCCESS, questionNumber));
     }
 

--- a/src/main/java/hirelah/logic/util/CommandUtil.java
+++ b/src/main/java/hirelah/logic/util/CommandUtil.java
@@ -13,7 +13,8 @@ public class CommandUtil {
     public static final String SAVE_INTERVIEWEE_ERROR_MESSAGE = "Could not save the updated interviewees to file: ";
     public static final String SAVE_METRICS_ERROR_MESSAGE = "Could not save the updated metrics to file: ";
     public static final String SAVE_QUESTIONS_ERROR_MESSAGE = "Could not save the updated questions to file: ";
-    public static final String SAVE_MODEL_ERROR_MESSAGE = "Could not save the updated model status to file: ";
+    public static final String SAVE_MODEL_ERROR_MESSAGE = "Could not save the updated finalise status to file: ";
+    public static final String SAVE_TRANSCRIPT_ERROR_MESSAGE = "Could not save the updated transcript to file: ";
     /**
      * Saves the updated AttributeList to the storage
      */
@@ -57,12 +58,26 @@ public class CommandUtil {
             throw new CommandException(SAVE_METRICS_ERROR_MESSAGE + ioe, ioe);
         }
     }
-    /**Save the finalised state of the model in the storage*/
+
+    /**
+     * Save the finalised state of the model in the storage
+     */
     public static void saveModel(Model model, Storage storage) throws CommandException {
         try {
             storage.saveModel(model.isFinalisedInterviewProperties());
         } catch (IOException ioe) {
             throw new CommandException(SAVE_MODEL_ERROR_MESSAGE + ioe, ioe);
+        }
+    }
+
+    /**
+     * Save the updated Transcript to the storage
+     */
+    public static void saveTranscript(Model model, Storage storage) throws CommandException {
+        try {
+            storage.saveTranscript(model.getCurrentInterviewee());
+        } catch (IOException ioe) {
+            throw new CommandException(SAVE_TRANSCRIPT_ERROR_MESSAGE + ioe, ioe);
         }
     }
 }

--- a/src/main/java/hirelah/storage/StorageManager.java
+++ b/src/main/java/hirelah/storage/StorageManager.java
@@ -70,6 +70,12 @@ public class StorageManager implements Storage {
 
     @Override
     public void loadSession(Model model, Path session) throws DataConversionException {
+        try {
+            Files.createDirectories(session);
+        } catch (IOException e) {
+            logger.severe("Unable to create sessions directory : " + StringUtil.getDetails(e));
+        }
+
         this.intervieweeStorage = new IntervieweeStorage(session.resolve("interviewee.json"));
         this.attributeStorage = new AttributeStorage(session.resolve("attribute.json"));
         this.questionStorage = new QuestionStorage(session.resolve("question.json"));


### PR DESCRIPTION
Update the DRY of storage methods in saving transcript

Fixes #197 

Also changes the new session command so it creates the directory immediately instead of when some change is made to the new session. This way a session will persist even if it is closed while still empty